### PR TITLE
Added summary and group picture of Signal 2025

### DIFF
--- a/2025/index.html
+++ b/2025/index.html
@@ -52,10 +52,31 @@ dinner?</a></li>
 <p><em>Navigate to:</em> <a href=".."><strong>SiREN main
 page</strong></a></p>
 <h2 id="welcome-to-siren-signal-2025">Welcome to SiREN Signal 2025</h2>
-<p>Siren Signal 2025 to be held in Gothenburg, June 2nd and June 3rd
-from Lunch to Lunch, at <a
+<p>Siren Signal 2025 was held in Gothenburg, June 2nd and June 3rd from
+Lunch to Lunch, at <a
 href="https://www.gu.se/en/study-gothenburg/campus-lindholmen">Campus
 Lindholmen</a>, near Lindholmspiren.</p>
+<p>Over the two half-days we heard a total of 13 presentations about
+various topics of requirements engineering (RE). We enjoyed several
+perspectives on how artificial intelligence (AI) affects RE (AI4RE) and
+vice versa (RE4AI), heard insights from industrial ambassadors, and
+considered yet underrepresented aspects like nature as a
+stakeholder.</p>
+<p>The SiREN Signal 2025 once more demonstrated how active, vibrant, and
+engaged the Swedish RE community is. Thank you to all the presenters,
+participants, discussants, and organizers for ensuring that SiREN Signal
+2025 became such a success.</p>
+<p><img src="../img/20250602.jpg" alt="SiREN 2025 participants" width="100%" height="auto"></p>
+<p><strong>Participants on day 1</strong> (from left to right):</p>
+<ul>
+<li>Front row: Eric Knauss, Beatriz Cabrero-Daniel, Björn Regnell, Khan
+Mohammad Habibullah</li>
+<li>Middle row: Krishna Ronanki, Romina Spalazzese, Yi Peng, Birgit
+Penzenstadler, Hina Saeeda, Lena Buffoni</li>
+<li>Back row: Peter Sjöberg, Krzysztof Wnuk, Muhammad Abbas, Sarmad
+Bashir, Jennifer Horkoff, Richard Berntsson-Svensson, Razan Ghzouli,
+Georgios Koutsopolous, Julian Frattini, Amna Pir</li>
+</ul>
 <h3 id="where-exactly-is-siren-signal-2025">Where exactly is SiREN
 Signal 2025?</h3>
 <ul>

--- a/src/2025.md
+++ b/src/2025.md
@@ -2,7 +2,21 @@
 
 ## Welcome to SiREN Signal 2025
 
-Siren Signal 2025 to be held in Gothenburg, June 2nd and June 3rd from Lunch to Lunch, at [Campus Lindholmen](https://www.gu.se/en/study-gothenburg/campus-lindholmen), near Lindholmspiren. 
+Siren Signal 2025 was held in Gothenburg, June 2nd and June 3rd from Lunch to Lunch, at [Campus Lindholmen](https://www.gu.se/en/study-gothenburg/campus-lindholmen), near Lindholmspiren. 
+
+Over the two half-days we heard a total of 13 presentations about various topics of requirements engineering (RE).
+We enjoyed several perspectives on how artificial intelligence (AI) affects RE (AI4RE) and vice versa (RE4AI), heard insights from industrial ambassadors, and considered yet underrepresented aspects like nature as a stakeholder.
+
+The SiREN Signal 2025 once more demonstrated how active, vibrant, and engaged the Swedish RE community is.
+Thank you to all the presenters, participants, discussants, and organizers for ensuring that SiREN Signal 2025 became such a success.
+
+<img src="../img/20250602.jpg" alt="SiREN 2025 participants" width="100%" height="auto">
+
+**Participants on day 1** (from left to right): 
+
+* Front row: Eric Knauss, Beatriz Cabrero-Daniel, Björn Regnell, Khan Mohammad Habibullah
+* Middle row: Krishna Ronanki, Romina Spalazzese, Yi Peng, Birgit Penzenstadler, Hina Saeeda, Lena Buffoni
+* Back row: Peter Sjöberg, Krzysztof Wnuk, Muhammad Abbas, Sarmad Bashir, Jennifer Horkoff, Richard Berntsson-Svensson, Razan Ghzouli, Georgios Koutsopolous, Julian Frattini, Amna Pir
 
 ### Where exactly is SiREN Signal 2025?
 


### PR DESCRIPTION
Added a brief summary of the past Signal 2025 held in Gothenburg. Kindly complement the summary in case any important aspect was missed.